### PR TITLE
10 i18n

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'sorcery'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
+gem 'rails-i18n'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (7.0.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.1.5)
       actionpack (= 6.1.5)
       activesupport (= 6.1.5)
@@ -308,6 +311,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.5)
+  rails-i18n
   rspec-rails (~> 5.0.0)
   rubocop
   rubocop-rails

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -4,7 +4,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to root_path, notice: 'login was successed.'
+      redirect_back_or_to root_path, notice: t('.success')
     else
       render :new
     end
@@ -12,6 +12,6 @@ class UserSessionsController < ApplicationController
 
   def destroy
     logout
-    redirect_to root_path, notice: 'logout was successed.'
+    redirect_to root_path, notice: t('.success')
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,9 +6,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to root_path, notice: 'User was successfully created.'
+      redirect_to root_path, notice: t('.success')
     else
-      flash.now[:danger] = 'faild'
+      flash.now[:danger] = t('.fail')
       render :new
     end
   end

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -14,11 +14,11 @@
         </div>
       </div>
         <div class="text-grey-dark mt-6">
-          登録がお済みでない方はこちらへ 
+          <%= t('.noaccount') %>
           <a class="no-underline border-b border-blue text-blue" href="/users/new">new</a>.
         </div>
         <div class="text-grey-dark mt-6">
-          パスワードをお忘れのかた 
+          <%= t('.forgot') %> 
           <a class="no-underline border-b border-blue text-blue" href="">password forgot</a>.
         </div>
     </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <div class="bg-white font-serif py-6 sm:py-8 lg:py-12">
   <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
     <div class="mb-10 md:mb-10">
-      <h2 class="text-2xl font-bold text-center lg:text-3xl mb-4 md:mb-6">新規登録</h2>
+      <h2 class="text-2xl font-bold text-center lg:text-3xl mb-4 md:mb-6"><%= t('.title') %></h2>
       <% if @user.errors.any? %>
         <div class="max-w-screen-md mx-auto">
           <div class="text-red-700 bg-red-100 border border-red-400 rounded px-4 py-3" role="alert">

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,9 +41,10 @@ module Wheretogo
       g.test_framework false
       g.jbuilder false
 
-      config.i18n.default_locale = :ja
       config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
-      config.time_zone = "Tokyo"
+      config.i18n.available_locales = %i(ja)
+      config.i18n.default_locale = :ja
+      config.time_zone = 'Tokyo'
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,10 @@ module Wheretogo
       g.helper false
       g.test_framework false
       g.jbuilder false
+
+      config.i18n.default_locale = :ja
+      config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+      config.time_zone = "Tokyo"
     end
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,12 @@
+ja:
+  activerecord:
+    models:
+      user: 'ユーザー'
+      like: 'いいね'
+    attributes:
+      user:
+        name: '名前'
+        email: 'メールアドレス'
+        password: 'パスワード'
+        password_confirmation: 'パスワード（確認）'
+        avatar: 'アイコン' 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,18 @@
+ja:
+  users:
+    new:
+      title: '新規登録'
+    create:
+      success: 'ユーザー登録が完了しました'
+      fail: 'ユーザー登録に失敗しました'
+  user_sessions:
+    new:
+      title: 'ログイン'
+      login_with_twitter: 'Twitterでログイン'
+      noaccount: 'アカウント新規登録はこちら'
+      forgot: 'パスワードをお忘れの方'
+    create:
+      success: 'ログインしました'
+      fail: 'ログインに失敗しました'
+    destroy:
+      success: 'ログアウトしました' 


### PR DESCRIPTION
## 概要
i18nを導入しました


## 確認項目



1. フラッシュメッセージ、各文字がi１８んを使用して日本語になっていること



## チェックリスト


- [ ] Lint のチェックをパスした
<img width="570" alt="スクリーンショット 2022-05-10 20 36 53" src="https://user-images.githubusercontent.com/89956278/167620102-542c14c2-2e52-4d28-971e-f917b73b36af.png">

## コメント
新規登録ページの必須の部分とアカウントをお持ちの方の部分が翻訳が反映されず、一旦日本語のままです
